### PR TITLE
feat: Introduce show_on_statement for ItemConfig

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-exclude = .git,__pycache__,dist,build,docs,docsrc/source/conf.py,lib,.venv,.venvs,venv,lib
+exclude = .git,__pycache__,dist,build,docs,docsrc/source/conf.py,Lib,.venv,.venvs,venv

--- a/finstmt/bs/config.py
+++ b/finstmt/bs/config.py
@@ -1086,6 +1086,6 @@ BALANCE_SHEET_INPUT_ITEMS = [
         forecast_config=ForecastItemConfig(
             make_forecast=False,
         ),
-        showOnStatement=False
+        show_on_statement=False
     ),
 ]

--- a/finstmt/bs/config.py
+++ b/finstmt/bs/config.py
@@ -1086,5 +1086,6 @@ BALANCE_SHEET_INPUT_ITEMS = [
         forecast_config=ForecastItemConfig(
             make_forecast=False,
         ),
+        showOnStatement=False
     ),
 ]

--- a/finstmt/bs/config.py
+++ b/finstmt/bs/config.py
@@ -1086,6 +1086,6 @@ BALANCE_SHEET_INPUT_ITEMS = [
         forecast_config=ForecastItemConfig(
             make_forecast=False,
         ),
-        show_on_statement=False
+        show_on_statement=False,
     ),
 ]

--- a/finstmt/bs/data.py
+++ b/finstmt/bs/data.py
@@ -11,8 +11,6 @@ from finstmt.findata.database import FinDataBase
 
 @dataclass(unsafe_hash=True)
 class BalanceSheetData(FinDataBase):
-    t = symbols("t", cls=Idx)
-
     def __init__(self, *args, **kwargs):
         _fields = [
             (
@@ -67,10 +65,6 @@ class BalanceSheetData(FinDataBase):
             "BalanceSheetData",
             fields=_fields,
             bases=(FinDataBase,),
-            # nwc now in the config file
-            # namespace={
-            #     "nwc": lambda self: self.receivables + self.inventory - self.payables
-            # },
         )
         MyClass.__module__ = "finstmt.bs.data"
         self.__class__ = MyClass
@@ -92,7 +86,6 @@ class BalanceSheetData(FinDataBase):
 
     # Get item even if attribute exists
     def __getattribute__(self, key: str):
-        # print("BalanceSheetData.__getattribute__", key)
         return object.__getattribute__(self, key)
 
     items_config_list = BALANCE_SHEET_INPUT_ITEMS

--- a/finstmt/bs/data.py
+++ b/finstmt/bs/data.py
@@ -18,7 +18,7 @@ class BalanceSheetData(FinDataBase):
             (
                 item.key,
                 numpy.float64,
-                field(default=0, repr=(False if item.key == "nwc" else True)),
+                field(default=0, repr=item.show_on_statement),
             )
             for item in self.items_config_list
         ]

--- a/finstmt/bs/data.py
+++ b/finstmt/bs/data.py
@@ -2,7 +2,6 @@ from copy import deepcopy
 from dataclasses import dataclass, field, make_dataclass
 
 import numpy
-from sympy import Idx, symbols
 
 from finstmt.bs.config import BALANCE_SHEET_INPUT_ITEMS
 from finstmt.config_manage.data import DataConfigManager

--- a/finstmt/inc/config.py
+++ b/finstmt/inc/config.py
@@ -38,6 +38,7 @@ INCOME_STATEMENT_INPUT_ITEMS = [
         forecast_config=ForecastItemConfig(
             make_forecast=False,
         ),
+        show_on_statement=False, # historically this was not shown on the statement. adding this here for backwards compatibility, but I think we can remove this.
     ),
     ItemConfig(
         "rd_exp",

--- a/finstmt/inc/config.py
+++ b/finstmt/inc/config.py
@@ -38,7 +38,7 @@ INCOME_STATEMENT_INPUT_ITEMS = [
         forecast_config=ForecastItemConfig(
             make_forecast=False,
         ),
-        show_on_statement=False, # historically this was not shown on the statement. adding this here for backwards compatibility, but I think we can remove this.
+        show_on_statement=False,  # historically this was not shown on the statement. adding this here for backwards compatibility, but I think we can remove this.
     ),
     ItemConfig(
         "rd_exp",

--- a/finstmt/inc/data.py
+++ b/finstmt/inc/data.py
@@ -2,7 +2,6 @@ from copy import deepcopy
 from dataclasses import dataclass, field, make_dataclass
 
 import numpy
-from sympy import Idx, symbols
 
 from finstmt.config_manage.data import DataConfigManager
 from finstmt.findata.database import FinDataBase

--- a/finstmt/inc/data.py
+++ b/finstmt/inc/data.py
@@ -11,8 +11,6 @@ from finstmt.inc.config import INCOME_STATEMENT_INPUT_ITEMS
 
 @dataclass(unsafe_hash=True)
 class IncomeStatementData(FinDataBase):
-    t = symbols("t", cls=Idx)
-
     def __init__(self, *args, **kwargs):
         _fields = [
             (
@@ -64,7 +62,6 @@ class IncomeStatementData(FinDataBase):
 
     # Get item even if attribute exists
     def __getattribute__(self, key: str):
-        # print("IncomeStatementData.__getattribute__", key)
         return object.__getattribute__(self, key)
 
     ###### THIS BREAKS THE DYNAMIC DATACLASS

--- a/finstmt/inc/data.py
+++ b/finstmt/inc/data.py
@@ -18,7 +18,7 @@ class IncomeStatementData(FinDataBase):
             (
                 item.key,
                 numpy.float64,
-                field(default=0, repr=(False if item.key == "gross_profit" else True)),
+                field(default=0, repr=item.show_on_statement),
             )
             for item in self.items_config_list
         ]

--- a/finstmt/items/config.py
+++ b/finstmt/items/config.py
@@ -21,7 +21,7 @@ class ItemConfig:
         default_factory=lambda: ForecastItemConfig()
     )
     expr_str: Optional[str] = None
-    show_on_statement: bool = True # Some properities, e.g., nwc and effective tax rate, may be associated with a statments but we don't necessarily want to display it on the print-out
+    show_on_statement: bool = True  # Some properities, e.g., nwc and effective tax rate, may be associated with a statments but we don't necessarily want to display it on the print-out
 
     # TODO [#19]: add config and logic for whether to take highest priority or add all of matching names
     #

--- a/finstmt/items/config.py
+++ b/finstmt/items/config.py
@@ -21,6 +21,7 @@ class ItemConfig:
         default_factory=lambda: ForecastItemConfig()
     )
     expr_str: Optional[str] = None
+    show_on_statement: bool = True # Some properities, e.g., nwc and effective tax rate, may be associated with a statments but we don't necessarily want to display it on the print-out
 
     # TODO [#19]: add config and logic for whether to take highest priority or add all of matching names
     #

--- a/tests/snapshot/__snapshots__/test_config/test_load[annual-capiq].txt
+++ b/tests/snapshot/__snapshots__/test_config/test_load[annual-capiq].txt
@@ -43,7 +43,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -419,7 +420,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -795,7 +797,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1171,7 +1174,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1547,7 +1551,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -2995,7 +3000,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -4107,7 +4113,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -5219,7 +5226,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -6331,7 +6339,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -7443,7 +7452,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 )

--- a/tests/snapshot/__snapshots__/test_config/test_load[annual-stockrow_cat].txt
+++ b/tests/snapshot/__snapshots__/test_config/test_load[annual-stockrow_cat].txt
@@ -43,7 +43,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -428,7 +429,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -813,7 +815,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1198,7 +1201,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1583,7 +1587,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1968,7 +1973,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -2353,7 +2359,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -2738,7 +2745,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -3123,7 +3131,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -3508,7 +3517,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -4993,7 +5003,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -6133,7 +6144,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -7273,7 +7285,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -8413,7 +8426,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -9553,7 +9567,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -10693,7 +10708,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -11833,7 +11849,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -12973,7 +12990,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -14113,7 +14131,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -15253,7 +15272,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 )

--- a/tests/snapshot/__snapshots__/test_config/test_load[annual-stockrow_mar].txt
+++ b/tests/snapshot/__snapshots__/test_config/test_load[annual-stockrow_mar].txt
@@ -43,7 +43,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -432,7 +433,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -821,7 +823,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1210,7 +1213,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1599,7 +1603,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1988,7 +1993,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -2377,7 +2383,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -2766,7 +2773,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -3155,7 +3163,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -3544,7 +3553,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -5015,7 +5025,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -6137,7 +6148,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -7259,7 +7271,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -8381,7 +8394,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -9503,7 +9517,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -10625,7 +10640,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -11747,7 +11763,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -12869,7 +12886,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -13991,7 +14009,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -15113,7 +15132,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 )

--- a/tests/snapshot/__snapshots__/test_config/test_load[quarterly-capiq].txt
+++ b/tests/snapshot/__snapshots__/test_config/test_load[quarterly-capiq].txt
@@ -43,7 +43,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -416,7 +417,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -789,7 +791,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1162,7 +1165,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1535,7 +1539,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1908,7 +1913,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -2281,7 +2287,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -2654,7 +2661,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -3027,7 +3035,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -3400,7 +3409,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -3773,7 +3783,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -4146,7 +4157,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -4519,7 +4531,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -4892,7 +4905,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -5265,7 +5279,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -5638,7 +5653,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -6011,7 +6027,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -6384,7 +6401,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -6757,7 +6775,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -7130,7 +7149,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -7503,7 +7523,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -7876,7 +7897,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -8249,7 +8271,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -8622,7 +8645,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -8995,7 +9019,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -9368,7 +9393,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -9741,7 +9767,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -10114,7 +10141,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -10487,7 +10515,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -10860,7 +10889,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -11233,7 +11263,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -12678,7 +12709,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -13790,7 +13822,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -14902,7 +14935,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -16014,7 +16048,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -17126,7 +17161,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -18238,7 +18274,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -19350,7 +19387,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -20462,7 +20500,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -21574,7 +21613,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -22686,7 +22726,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -23798,7 +23839,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -24910,7 +24952,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -26022,7 +26065,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -27134,7 +27178,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -28246,7 +28291,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -29358,7 +29404,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -30470,7 +30517,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -31582,7 +31630,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -32694,7 +32743,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -33806,7 +33856,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -34918,7 +34969,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -36030,7 +36082,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -37142,7 +37195,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -38254,7 +38308,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -39366,7 +39421,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -40478,7 +40534,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -41590,7 +41647,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -42702,7 +42760,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -43814,7 +43873,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -44926,7 +44986,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -46038,7 +46099,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 )

--- a/tests/snapshot/__snapshots__/test_config/test_load[quarterly-stockrow_cat].txt
+++ b/tests/snapshot/__snapshots__/test_config/test_load[quarterly-stockrow_cat].txt
@@ -43,7 +43,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -428,7 +429,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -813,7 +815,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1198,7 +1201,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1583,7 +1587,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1968,7 +1973,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -2353,7 +2359,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -2738,7 +2745,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -3123,7 +3131,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -3508,7 +3517,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -3893,7 +3903,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -4278,7 +4289,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -4663,7 +4675,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -5048,7 +5061,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -5433,7 +5447,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -5818,7 +5833,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -6203,7 +6219,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -6588,7 +6605,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -6973,7 +6991,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -7358,7 +7377,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -7743,7 +7763,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -8128,7 +8149,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -8513,7 +8535,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -8898,7 +8921,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -9283,7 +9307,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -9668,7 +9693,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -10053,7 +10079,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -10438,7 +10465,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -10823,7 +10851,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -11208,7 +11237,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -11593,7 +11623,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -11978,7 +12009,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -12363,7 +12395,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -12748,7 +12781,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -13133,7 +13167,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -13518,7 +13553,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -13903,7 +13939,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -14288,7 +14325,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -14673,7 +14711,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -15058,7 +15097,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -16543,7 +16583,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -17683,7 +17724,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -18823,7 +18865,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -19963,7 +20006,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -21103,7 +21147,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -22243,7 +22288,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -23383,7 +23429,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -24523,7 +24570,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -25663,7 +25711,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -26803,7 +26852,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -27943,7 +27993,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -29083,7 +29134,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -30223,7 +30275,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -31363,7 +31416,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -32503,7 +32557,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -33643,7 +33698,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -34783,7 +34839,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -35923,7 +35980,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -37063,7 +37121,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -38203,7 +38262,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -39343,7 +39403,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -40483,7 +40544,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -41623,7 +41685,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -42763,7 +42826,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -43903,7 +43967,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -45043,7 +45108,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -46183,7 +46249,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -47323,7 +47390,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -48463,7 +48531,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -49603,7 +49672,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -50743,7 +50813,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -51883,7 +51954,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -53023,7 +53095,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -54163,7 +54236,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -55303,7 +55377,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -56443,7 +56518,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -57583,7 +57659,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -58723,7 +58800,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -59863,7 +59941,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -61003,7 +61082,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 )

--- a/tests/snapshot/__snapshots__/test_config/test_load[quarterly-stockrow_mar].txt
+++ b/tests/snapshot/__snapshots__/test_config/test_load[quarterly-stockrow_mar].txt
@@ -43,7 +43,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -432,7 +433,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -821,7 +823,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1210,7 +1213,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1599,7 +1603,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -1988,7 +1993,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -2377,7 +2383,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -2766,7 +2773,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -3155,7 +3163,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -3544,7 +3553,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -3933,7 +3943,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -4322,7 +4333,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -4711,7 +4723,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -5100,7 +5113,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -5489,7 +5503,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -5878,7 +5893,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -6267,7 +6283,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -6656,7 +6673,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -7045,7 +7063,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -7434,7 +7453,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -7823,7 +7843,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -8212,7 +8233,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -8601,7 +8623,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -8990,7 +9013,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -9379,7 +9403,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -9768,7 +9793,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -10157,7 +10183,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -10546,7 +10573,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -10935,7 +10963,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -11324,7 +11353,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -11713,7 +11743,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -12102,7 +12133,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -12491,7 +12523,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -12880,7 +12913,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -13269,7 +13303,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -13658,7 +13693,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -14047,7 +14083,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -14436,7 +14473,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -14825,7 +14863,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -15214,7 +15253,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='revenue[t] - cogs[t]'
+                            expr_str='revenue[t] - cogs[t]',
+                            show_on_statement=False
                         ),
                         finstmt.items.config.ItemConfig(
                             key='rd_exp',
@@ -16685,7 +16725,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -17807,7 +17848,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -18929,7 +18971,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -20051,7 +20094,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -21173,7 +21217,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -22295,7 +22340,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -23417,7 +23463,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -24539,7 +24586,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -25661,7 +25709,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -26783,7 +26832,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -27905,7 +27955,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -29027,7 +29078,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -30149,7 +30201,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -31271,7 +31324,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -32393,7 +32447,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -33515,7 +33570,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -34637,7 +34693,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -35759,7 +35816,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -36881,7 +36939,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -38003,7 +38062,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -39125,7 +39185,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -40247,7 +40308,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -41369,7 +41431,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -42491,7 +42554,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -43613,7 +43677,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -44735,7 +44800,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -45857,7 +45923,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -46979,7 +47046,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -48101,7 +48169,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -49223,7 +49292,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -50345,7 +50415,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -51467,7 +51538,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -52589,7 +52661,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -53711,7 +53784,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -54833,7 +54907,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -55955,7 +56030,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -57077,7 +57153,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -58199,7 +58276,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -59321,7 +59399,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 ),
@@ -60443,7 +60522,8 @@ finstmt.config_manage.statements.StatementsConfigManager(
                             forecast_config=finstmt.forecast.config.ForecastItemConfig(
                                 make_forecast=False
                             ),
-                            expr_str='receivables[t] + inventory[t] - payables[t]'
+                            expr_str='receivables[t] + inventory[t] - payables[t]',
+                            show_on_statement=False
                         )
                     ]
                 )


### PR DESCRIPTION
Some properties, e.g., nwc and effective tax rate, may be associated with a statement but haven't historically surfaced on the print-outs.
Making this configurable in the ItemConfig takes us a step closer to having a generic statement class.

Note: the config snapshots have again been updated in this PR to reflect the new attribute